### PR TITLE
Fix App Runner build command

### DIFF
--- a/create-service-input.json
+++ b/create-service-input.json
@@ -15,7 +15,7 @@
         "ConfigurationSource": "API",
         "CodeConfigurationValues": {
           "Runtime": "PYTHON_311",
-          "BuildCommand": "pip install --upgrade pip && pip install --target /app/backend/.deps -r requirements.txt && python3 manage.py migrate --no-input && python3 manage.py collectstatic --no-input",
+          "BuildCommand": "python3 -m pip install --upgrade pip && python3 -m pip install --target /app/backend/.deps -r requirements.txt && python3 manage.py migrate --no-input && python3 manage.py collectstatic --no-input",
           "StartCommand": "sh -c \"export PYTHONPATH=/app/backend/.deps:$PYTHONPATH && python3 -m gunicorn virtual_finance.wsgi:application --bind 0.0.0.0:8000\"",
           "Port": "8000",
           "RuntimeEnvironmentVariables": {


### PR DESCRIPTION
## Summary
- update create-service input to use `python3 -m pip` instead of `pip`

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842a6539f9c8330b325e74834d35b49